### PR TITLE
Fix typo in string indices in "script_excerpt" method

### DIFF
--- a/src/transformation.py
+++ b/src/transformation.py
@@ -76,7 +76,7 @@ class Transformation:
     @staticmethod
     def script_excerpt(script):
         if len(script) > 1000:
-            return script[0, 500] + '\n...\n' + script[-500]
+            return script[0 : 500] + '\n...\n' + script[-500]
         else:
             return script
 


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-403
Changes:
- Fixed bad string indices `[0, 500]` -> `[0 : 500]`.