### PR TITLE
INC-15679 Fix ENV for running `pip install`

### DIFF
--- a/bandersnatch.conf
+++ b/bandersnatch.conf
@@ -121,3 +121,4 @@ enabled =
 packages =
     art==5.3
     configparser2>=4.0.0
+    pysftp==0.2.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         BASE_IMAGE_NAME: keboola.azurecr.io/docker-custom-python
         BASE_IMAGE_TAG: python-3.10-7.0.3
     image: keboola/python-transformation-v2
-    user: www-data
+    user: "1000"
     tty: true
     stdin_open: true
 
@@ -18,7 +18,7 @@ services:
         BASE_IMAGE_NAME: keboola.azurecr.io/docker-python-snowpark
         BASE_IMAGE_TAG: python-3.8-7.0.3
     image: keboola/python-snowpark-transformation
-    user: www-data
+    user: "1000"
     tty: true
     stdin_open: true
 

--- a/kbc_transformation/transformation.py
+++ b/kbc_transformation/transformation.py
@@ -86,9 +86,10 @@ class Transformation:
                 package
             ]
 
-            p = run(args, capture_output = True, env={
-                'PIP_CONFIG_FILE': self.pipFile,
-            })
+            env = os.environ.copy()
+            env['PIP_CONFIG_FILE'] = self.pipFile
+
+            p = run(args, capture_output = True, env=env)
             print(p.stdout.decode())
             if p.returncode != 0:
                 print(p.stderr.decode())

--- a/tests/package/config.json
+++ b/tests/package/config.json
@@ -1,6 +1,6 @@
 {
     "parameters": {
-        "packages": ["art"],
+        "packages": ["pysftp", "art"],
         "blocks": [
             {
                 "name": "block 1",


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C06SNFYFDMK

* oprava nastaveni ENV pro `pip install` (`env` kompletne prepisuje ENV subprocesu, takze je potreba ho ruco mergnout s aktualnim)
* pridani instalace `pysftp` do testu, ktery ma slozitejsi install fazi (ten failoval u jednoho z klientu)
* upraveni `docker-compose` aby poustel testy pod userem `1000`, jako queue (puvodni `www-data` je systemovy user, u ktereho se chyba neprojevovala)