### PR TITLE
INC-18063 Install keboola.component as dependency of kbc_transformation lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     url='https://github.com/keboola/python-transformation-v2',
     packages=['kbc_transformation'],
     requires=['pip'],
+    install_requires=['keboola.component'],
     license="MIT"
 )


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C07J7EB1FU7

Nedari se start Jupyerlabu a v logach je videt
```
[E 2024-08-27 07:21:54.144 ServerApp] Exception while loading config file /etc/jupyter/jupyter_server_config.py
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/site-packages/traitlets/config/application.py", line 915, in _load_config_files
        config = loader.load_config()
      File "/usr/local/lib/python3.10/site-packages/traitlets/config/loader.py", line 622, in load_config
        self._read_file_as_dict()
      File "/usr/local/lib/python3.10/site-packages/traitlets/config/loader.py", line 655, in _read_file_as_dict
        exec(compile(f.read(), conf_filename, "exec"), namespace, namespace)  # noqa: S102
      File "/etc/jupyter/jupyter_server_config.py", line 10, in <module>
        from kbc_transformation.transformation import Transformation
      File "/usr/local/lib/python3.10/site-packages/kbc_transformation/transformation.py", line 2, in <module>
        from keboola.component import CommonInterface
    ModuleNotFoundError: No module named 'keboola.component'
```

Z toho jsme dohledali, ze `kbc_transformation` nema v dependencies vubec `keboola.component` uvedeny.

Lokalne mam otestovany, ze s takle upravenym `kbc_transformation`  se dependency spravne nainstaluje a Jupyterlab najede.