### PR TITLE
AJDA-2930 Add deprecation notice pointing to runtime-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> [!WARNING]
+> **Deprecated — this repository is no longer used to build images.**
+>
+> The `keboola.python-transformation-v2` image is now built and published from the
+> [keboola/runtime-images](https://github.com/keboola/runtime-images) monorepo, in the
+> [`python-transformation-v2`](https://github.com/keboola/runtime-images/tree/main/python-transformation-v2)
+> directory. That workflow builds one image per supported Python version and pushes the **same** image
+> to the Developer Portal ECR under both `keboola.python-transformation-v2` and
+> `keboola.csas-python-transformation-v2`.
+>
+> Make all changes there. This repository is kept for history only and its code is not released.
+
 [![Build Status](https://dev.azure.com/keboola-dev/Data%20Science/_apis/build/status/keboola.python-transformation-v2?branchName=master)](https://dev.azure.com/keboola-dev/Data%20Science/_build/latest?definitionId=74&branchName=master)
 
 Application which runs KBC transformations writen in Python, interface is provided by [docker-bundle](https://github.com/keboola/docker-bundle).


### PR DESCRIPTION
@
## Link to issue

https://linear.app/keboola/issue/AJDA-2930

## Description

Adds a deprecation warning to the top of `README.md` stating that this repository no longer builds any image. The `keboola.python-transformation-v2` image is now built and published from the [keboola/runtime-images](https://github.com/keboola/runtime-images) monorepo (`python-transformation-v2/` directory), whose workflow pushes the same image under both `keboola.python-transformation-v2` and `keboola.csas-python-transformation-v2`. The notice makes explicit that changes belong in `runtime-images` and that this repo is kept for history only.

Documentation only - no code, CI, or image changes. The same note was added to the CSAS repo in keboola/csas-python-transformation-v2#29.

## Justification

The image build was consolidated into the `runtime-images` monorepo. Without a notice here, anyone landing on this repo would keep making changes that are never released.

## Plans for Customer Communication

None.

## Impact Analysis

None - README-only change. No effect on builds, published images, or any stack (including single-tenants).

## Deployment Plan

None - nothing is built or released from this repository.

## Rollback Plan

Revert this PR.

## Post-Release Support Plan

None.
@